### PR TITLE
Fix potential memory corruption in Shader.cpp

### DIFF
--- a/gl/shaders/Shader.cpp
+++ b/gl/shaders/Shader.cpp
@@ -283,6 +283,7 @@ void Shader::discoverUniforms() {
         GLint arraySize = 0;
         GLenum type;
         GLchar name[bufSize];
+        memset(name, 0, sizeof(name));
         glGetActiveUniform(m_programID, i, bufSize, &nameLength, &arraySize, &type, name);
         name[std::min(nameLength, bufSize - 1)] = 0;
 
@@ -300,6 +301,8 @@ void Shader::discoverUniforms() {
 
 bool Shader::isUniformArray(const GLchar *name, GLsizei nameLength) {
     // Check if the last 3 characters are '[0]'
+    if (nameLength < 3)
+        return false;
     return (name[nameLength - 3] == '[') &&
            (name[nameLength - 2] == '0') &&
            (name[nameLength - 1] == ']');


### PR DESCRIPTION
Leaving these values unitialized gives us the following error:
"Conditional jump or move depends on uninitialised value(s)" at
Shader.cpp:304:0.

So initialize the name buffer to 0, and check that nameLength doesn't
cause us to read out-of-bounds.

Signed-off-by: Desmond Cheong Zhi Xi <desmondcheongzx@gmail.com>